### PR TITLE
Fix spelling error in swap_arc.rs

### DIFF
--- a/src/swap_arc.rs
+++ b/src/swap_arc.rs
@@ -5,7 +5,7 @@
 /// to be passed around and swapped out with other `Arc`s.
 /// In order to achieve this, an internal reference count
 /// scheme is used which allows for very quick, low overhead
-/// reads in the common case (no update) and will sill be
+/// reads in the common case (no update) and will still be
 /// decently fast when an update is performed, as updates
 /// only consist of 3 atomic instructions. When a new
 /// `Arc` is to be stored in the `SwapArc`, it first tries to


### PR DESCRIPTION
Also, it seems like the /* */ comment which is probably supposed to go around the entire file doesn't work, because inside there are other /* */ comments (the first part gets interpreted as part of the comment, the second ends it)